### PR TITLE
better asset unlocks

### DIFF
--- a/src/blockdata/transaction/special_transaction/asset_unlock/request_info.rs
+++ b/src/blockdata/transaction/special_transaction/asset_unlock/request_info.rs
@@ -12,15 +12,11 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-//! Dash Credit Withdrawal Special Transaction.
+//! Dash Asset unlock Special Transaction request info.
 //!
-//! The credit withdrawal special transaction is used to withdraw from the asset lock credit pool.
+//! The asset unlock special transaction is used to withdraw from the asset lock credit pool.
 //!
-//!
-//! It is defined in DIPX https://github.com/dashpay/dips/blob/master/dip-000X.md as follows:
-//!
-//!
-//! The special transaction type used for CrWithTx Transactions is 9.
+//! The request info should be added once the quorum selection for signing has been made.
 
 use ::{io};
 use io::{Error, Write};
@@ -28,14 +24,9 @@ use consensus::{Decodable, Encodable, encode};
 use ::{QuorumHash};
 use prelude::*;
 
-/// A Credit Withdrawal payload. This is contained as the payload of a credit withdrawal special
-/// transaction.
-/// The Credit Withdrawal Special transaction and this payload is described in the Asset Lock DIP2X
-/// (todo:update this).
-/// The Credit Withdrawal Payload is signed by a quorum.
-///
-/// Transaction using it have no inputs. Hence the proof of validity lies solely on the BLS signature.
-///
+/// An asset unlock request info
+/// This is the information about the signing quorum
+/// The request height should be the height at which the specified quorum is active on core.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AssetUnlockRequestInfo {

--- a/src/blockdata/transaction/special_transaction/asset_unlock/unqualified_asset_unlock.rs
+++ b/src/blockdata/transaction/special_transaction/asset_unlock/unqualified_asset_unlock.rs
@@ -30,6 +30,7 @@ use blockdata::transaction::special_transaction::TransactionType::AssetUnlock;
 use consensus::{Decodable, Encodable, encode};
 use consensus::encode::MAX_VEC_SIZE;
 use TxIn;
+use prelude::*;
 
 /// An Asset Unlock Base payload. This is the base payload of the Asset Unlock. In order to make
 /// it a full payload the request info should be added.

--- a/src/blockdata/transaction/special_transaction/asset_unlock/unqualified_asset_unlock.rs
+++ b/src/blockdata/transaction/special_transaction/asset_unlock/unqualified_asset_unlock.rs
@@ -12,34 +12,36 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-//! Dash Credit Withdrawal Special Transaction.
+//! Dash Asset Unlock Base Special Transaction and Payload.
 //!
-//! The credit withdrawal special transaction is used to withdraw from the asset lock credit pool.
+//! These base elements are used in withdrawal queues.
 //!
 //!
 //! It is defined in DIPX https://github.com/dashpay/dips/blob/master/dip-000X.md as follows:
 //!
 //!
-//! The special transaction type used for CrWithTx Transactions is 9.
+//! The special transaction type used for AssetUnlockTx Transactions is 9.
 
 use io::{Error, Write};
-use io;
+use std::convert::TryFrom;
+use ::{io, TxOut};
+use blockdata::transaction::special_transaction::TransactionType;
+use blockdata::transaction::special_transaction::TransactionType::AssetUnlock;
 use consensus::{Decodable, Encodable, encode};
+use consensus::encode::MAX_VEC_SIZE;
+use TxIn;
 
-/// A Credit Withdrawal payload. This is contained as the payload of a credit withdrawal special
-/// transaction.
-/// The Credit Withdrawal Special transaction and this payload is described in the Asset Lock DIP2X
-/// (todo:update this).
-/// The Credit Withdrawal Payload is signed by a quorum.
-///
-/// Transaction using it have no inputs. Hence the proof of validity lies solely on the BLS signature.
-///
+/// An Asset Unlock Base payload. This is the base payload of the Asset Unlock. In order to make
+/// it a full payload the request info should be added.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AssetUnlockBasePayload {
-    version: u8,
-    index: u64,
-    fee: u32,
+    /// The payload protocol version, is currently expected to be 0.
+    pub version: u8,
+    /// The index of the unlock transaction. It gets bumped on each transaction
+    pub index: u64,
+    /// The fee used in Duffs (Satoshis)
+    pub fee: u32,
 }
 
 impl Encodable for AssetUnlockBasePayload {
@@ -64,3 +66,52 @@ impl Decodable for AssetUnlockBasePayload {
         })
     }
 }
+
+/// An Asset Unlock Base Transaction Info. This is the base transaction information that is needed
+/// to be kept in withdrawal queues.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct AssetUnlockBaseTransactionInfo {
+    /// The protocol version, is currently expected to be 1 or 2 (BIP 68).
+    pub version: u16,
+    /// Block number before which this transaction is valid, or 0 for valid immediately.
+    pub lock_time: u32,
+    /// List of transaction outputs.
+    pub output: Vec<TxOut>,
+    /// Base payload information
+    pub base_payload: AssetUnlockBasePayload,
+}
+
+impl Encodable for AssetUnlockBaseTransactionInfo {
+    fn consensus_encode<S: Write>(&self, mut s: S) -> Result<usize, Error> {
+        let mut len = 0;
+        len += self.version.consensus_encode(&mut s)?;
+        len += (AssetUnlock as u16).consensus_encode(&mut s)?;
+        len += Vec::<TxIn>::new().consensus_encode(&mut s)?;
+        len += self.output.consensus_encode(&mut s)?;
+        len += self.lock_time.consensus_encode(&mut s)?;
+        len += self.base_payload.consensus_encode(&mut s)?;
+        Ok(len)
+    }
+}
+
+impl Decodable for AssetUnlockBaseTransactionInfo {
+    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
+        let mut d = d.take(MAX_VEC_SIZE as u64);
+        let version = u16::consensus_decode(&mut d)?;
+        let special_transaction_type_u16 = u16::consensus_decode(&mut d)?;
+        let special_transaction_type = TransactionType::try_from(special_transaction_type_u16).map_err(|_| encode::Error::UnknownSpecialTransactionType(special_transaction_type_u16))?;
+        if special_transaction_type != AssetUnlock {
+            return Err(encode::Error::WrongSpecialTransactionPayloadConversion{ expected: AssetUnlock, actual: special_transaction_type})
+        }
+        Vec::<TxIn>::consensus_decode(&mut d)?; //no inputs
+        Ok(AssetUnlockBaseTransactionInfo {
+            version,
+            output: Decodable::consensus_decode(&mut d)?,
+            lock_time: Decodable::consensus_decode(&mut d)?,
+            base_payload: AssetUnlockBasePayload::consensus_decode(d)?
+        })
+    }
+}
+
+

--- a/src/blockdata/transaction/special_transaction/asset_unlock/unqualified_asset_unlock.rs
+++ b/src/blockdata/transaction/special_transaction/asset_unlock/unqualified_asset_unlock.rs
@@ -23,7 +23,7 @@
 //! The special transaction type used for AssetUnlockTx Transactions is 9.
 
 use io::{Error, Write};
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 use ::{io, TxOut};
 use blockdata::transaction::special_transaction::TransactionType;
 use blockdata::transaction::special_transaction::TransactionType::AssetUnlock;

--- a/src/blockdata/transaction/special_transaction/mod.rs
+++ b/src/blockdata/transaction/special_transaction/mod.rs
@@ -193,7 +193,7 @@ impl TransactionPayload {
 /// The first part for the version and the second part for the transaction
 /// type.
 ///
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
 pub enum TransactionType {
     /// A Classic transaction


### PR DESCRIPTION
This allows the base of asset unlocks to be serialized as if they were a transaction. We can then add extra request info when it is known.